### PR TITLE
Headings note

### DIFF
--- a/Content/Headings.md
+++ b/Content/Headings.md
@@ -1,3 +1,4 @@
+All headings...
 # h1 Heading
 ## h2 Heading
 ### h3 Heading
@@ -5,58 +6,35 @@
 ##### h5 Heading
 ###### h6 Heading
 
-
+- - -
+Headings placed in relation to body text, with no extra spacing.
 # h1 Heading 2
-
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse efficitur malesuada dolor et feugiat. Maecenas at risus ut ipsum rutrum maximus a id arcu. Curabitur tortor nulla, ultricies mattis neque ut, elementum interdum nisl. Nam dapibus tempus ornare. Fusce fringilla lectus sit amet orci rhoncus mollis. ^038507
-
-
 ## h2 Heading
-
 Sed posuere eu nisl et consectetur. Curabitur dignissim, nisl eu blandit scelerisque, tortor elit bibendum augue, ut scelerisque dui quam elementum velit. Nunc ullamcorper purus non ex condimentum, id porttitor diam pharetra. Integer ac accumsan lacus, sed varius erat. Proin mollis felis quis elementum consequat. Etiam faucibus congue arcu et finibus. Duis efficitur ipsum eget feugiat ullamcorper. Proin sed porta lectus, vitae cursus felis. Nulla at nibh nibh.
-
-
 ### h3 Heading
-
 Maecenas consequat, sem sit amet mollis ultrices, libero libero blandit turpis, ut lobortis mauris eros quis dui. Nam ante velit, egestas et egestas a, venenatis in nunc.
-
-
 #### h4 Heading
-
 Phasellus placerat leo dui, ac iaculis nunc congue ut. Donec sed risus tincidunt, fermentum diam vel, aliquam felis. Pellentesque et dictum est.
-
-
 ##### h5 Heading
-
 Nullam tristique molestie sem faucibus venenatis. Nam nisi odio, finibus a urna nec, rhoncus sagittis nulla. Nulla eget velit tincidunt, rutrum lectus in, varius turpis. Aenean blandit vitae est vitae dapibus.
-
-
 ###### h6 Heading
-
 Sed et scelerisque orci. Praesent non neque eget nisl rutrum aliquet. Duis vitae augue sit amet ante tempus posuere. Nulla interdum lacus tortor, sit amet finibus dui auctor eget.
 
-
+- - -
+Headings placed in relation to subheadings and body text.
 # h1 Heading
 ## h2 Heading
-
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse efficitur malesuada dolor et feugiat. Maecenas at risus ut ipsum rutrum maximus a id arcu.
-
 ## h2 Heading
 ### h3 Heading
-
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse efficitur malesuada dolor et feugiat. Maecenas at risus ut ipsum rutrum maximus a id arcu.
-
 ### h3 Heading
 #### h4 Heading
-
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse efficitur malesuada dolor et feugiat. Maecenas at risus ut ipsum rutrum maximus a id arcu.
-
 #### h4 Heading
 ##### h5 Heading
-
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse efficitur malesuada dolor et feugiat. Maecenas at risus ut ipsum rutrum maximus a id arcu.
-
 ##### h5 Heading
 ###### h6 Heading
-
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse efficitur malesuada dolor et feugiat. Maecenas at risus ut ipsum rutrum maximus a id arcu.

--- a/Content/Headings.md
+++ b/Content/Headings.md
@@ -38,3 +38,25 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse efficitur m
 ##### h5 Heading
 ###### h6 Heading
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse efficitur malesuada dolor et feugiat. Maecenas at risus ut ipsum rutrum maximus a id arcu.
+
+- - -
+Headings with links
+# [[Markdown|Heading 1 – note exists]]
+# [[NoSuchFile|Heading 1 – note doesn't exist]]
+# [[https://obsidian.md|Heading 1 – external]]
+## [[Markdown|Heading 2 – note exists]]
+## [[NoSuchFile|Heading 2 – note doesn't exist]]
+## [[https://obsidian.md|Heading 2 – external]]
+### [[Markdown|Heading 3 – note exists]]
+### [[NoSuchFile|Heading 3 – note doesn't exist]]
+### [[https://obsidian.md|Heading 3 – external]]
+#### [[Markdown|Heading 4 – note exists]]
+#### [[NoSuchFile|Heading 4 – note doesn't exist]]
+#### [[https://obsidian.md|Heading 4 – external]]
+##### [[Markdown|Heading 5 – note exists]]
+##### [[NoSuchFile|Heading 5 – note doesn't exist]]
+##### [[https://obsidian.md|Heading 5 – external]]
+###### [[Markdown|Heading 6 – note exists]]
+###### [[NoSuchFile|Heading 6 – note doesn't exist]]
+###### [[https://obsidian.md|Heading 6 – external]]
+


### PR DESCRIPTION
A couple of adjustments to the Headings note.

First, I've removed empty lines. This makes it easier to see the inherent spacing that the theme developer is applying as CSS.

Second, I've added a section for headings that are links. As these will typically be a different colour, it's useful to see how they look against the note background, and especially whether they have enough contrast for readability.